### PR TITLE
fix(render): fit lighting uniforms within downlevel limits

### DIFF
--- a/crates/patinae-render/src/passes/lighting.rs
+++ b/crates/patinae-render/src/passes/lighting.rs
@@ -12,7 +12,11 @@ use crate::memory::{buffer_usage, estimate_texture_2d_bytes, GpuMemoryUsage};
 
 pub const OCCLUSION_DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 pub const DEFAULT_SHADOW_MAP_SIZE: u32 = 1024;
-pub const MAX_ATLAS_DIRECTIONS: usize = 256;
+/// Keep the lighting uniform within wgpu's 16 KiB downlevel binding limit.
+///
+/// `LightingOcclusionUniforms` has a 96-byte fixed header and one 64-byte
+/// matrix per atlas direction, so 254 directions occupy 16,352 bytes.
+pub const MAX_ATLAS_DIRECTIONS: usize = 254;
 
 pub const OCCLUSION_MODE_DISABLED: u32 = 0;
 pub const OCCLUSION_MODE_ATLAS_AO: u32 = 1;
@@ -275,4 +279,31 @@ pub(crate) const fn identity_mat4() -> [[f32; 4]; 4] {
         [0.0, 0.0, 1.0, 0.0],
         [0.0, 0.0, 0.0, 1.0],
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lighting_occlusion_uniforms_fit_downlevel_binding_limit() {
+        let size = std::mem::size_of::<LightingOcclusionUniforms>() as u64;
+        let limit = wgpu::Limits::downlevel_defaults().max_uniform_buffer_binding_size;
+
+        assert!(
+            size <= limit,
+            "lighting occlusion uniform is {size} bytes, exceeding the downlevel {limit}-byte binding limit"
+        );
+    }
+
+    #[test]
+    fn lighting_shader_matches_atlas_direction_capacity() {
+        let shader = include_str!("../shaders/common/lighting.wgsl");
+        let declaration = format!("const MAX_ATLAS_DIRECTIONS: u32 = {MAX_ATLAS_DIRECTIONS}u;");
+
+        assert!(
+            shader.contains(&declaration),
+            "lighting WGSL must keep MAX_ATLAS_DIRECTIONS in sync with Rust"
+        );
+    }
 }

--- a/crates/patinae-render/src/shaders/common/lighting.wgsl
+++ b/crates/patinae-render/src/shaders/common/lighting.wgsl
@@ -13,11 +13,14 @@
 // All lighting vectors live in view space: camera at origin, fragments at
 // `view_pos`, view_dir = -view_pos. Shadow lookup uses world-space positions.
 
+// Keep in sync with passes::lighting::MAX_ATLAS_DIRECTIONS.
+const MAX_ATLAS_DIRECTIONS: u32 = 254u;
+
 struct LightingOcclusionUniforms {
     view_proj: mat4x4<f32>,
     params: vec4<f32>,
     atlas: vec4<u32>,
-    matrices: array<mat4x4<f32>, 256>,
+    matrices: array<mat4x4<f32>, MAX_ATLAS_DIRECTIONS>,
 };
 
 @group(1) @binding(0) var occlusion_depth: texture_depth_2d;
@@ -155,7 +158,7 @@ fn atlas_tile_depth(world_pos: vec3<f32>, index: u32) -> vec2<f32> {
 }
 
 fn atlas_ambient_occlusion(world_pos: vec3<f32>) -> f32 {
-    let count = min(occlusion.atlas.x, 256u);
+    let count = min(occlusion.atlas.x, MAX_ATLAS_DIRECTIONS);
     let intensity = occlusion.params.y;
     if count == 0u || intensity <= 0.0 {
         return 1.0;


### PR DESCRIPTION
## Summary

Fix the lighting/occlusion uniform layout so it fits within wgpu's 16 KiB downlevel uniform-buffer binding limit.

`LightingOcclusionUniforms` previously contained a 96-byte header plus 256 `mat4x4<f32>` values, for a total binding size of 16,480 bytes. On a Windows system using Intel HD Graphics 530, the device exposes a 16,384-byte uniform binding limit, so `patinae.lighting_occlusion.bind_group` fails validation and the loaded structure is never rendered.

This change:

* reduces the atlas direction capacity from 256 to 254, bringing the uniform to 16,352 bytes;
* keeps the Rust and WGSL capacities in sync;
* uses the same WGSL constant for the atlas AO loop bound;
* adds a regression test against `wgpu::Limits::downlevel_defaults().max_uniform_buffer_binding_size`;
* adds a test that keeps the WGSL direction constant synchronized with the Rust constant.

## Reproduction

Observed with the native Windows binary on Intel HD Graphics 530:

```text
In Device::create_bind_group, label = 'patinae.lighting_occlusion.bind_group'
  Buffer binding 2 range 16480 exceeds `max_*_buffer_binding_size` limit 16384
```

The PDB loads and the GPU is detected, but render submission repeatedly fails because the lighting bind group is invalid.

## Notes

254 directions preserve the existing 16x16 atlas layout while fitting the downlevel binding limit. A future refactor could move atlas matrices into a separate storage buffer if retaining or expanding the full 256-direction capacity becomes important.
