### PR TITLE
fix(windows): request compute-capable WGPU limits

### DIFF
--- a/patinae/src/app.rs
+++ b/patinae/src/app.rs
@@ -2594,11 +2594,12 @@ mod tests {
     }
 
     #[test]
-    fn wgpu_settings_request_compute_capable_limits() {
+    fn wgpu_settings_requests_compute_capable_limits() {
         let settings = patinae_wgpu_settings();
         let limits = settings.device_required_limits;
 
         assert!(limits.max_compute_workgroups_per_dimension > 0);
+        assert!(limits.max_compute_workgroup_size_x >= 64);
         assert!(limits.max_compute_invocations_per_workgroup >= 64);
         assert!(limits.max_storage_buffer_binding_size > 0);
         assert!(limits.max_storage_textures_per_shader_stage > 0);

--- a/patinae/src/app.rs
+++ b/patinae/src/app.rs
@@ -1465,6 +1465,7 @@ fn patinae_wgpu_settings() -> slint::wgpu_29::WGPUSettings {
         slint::wgpu_29::wgpu::Backends::from_env(),
         cfg!(target_os = "windows"),
     );
+    settings.device_required_limits = slint::wgpu_29::wgpu::Limits::default();
     settings
         .device_required_limits
         .max_storage_buffers_per_shader_stage = RENDER_COMPUTE_STORAGE_BUFFERS_PER_STAGE;
@@ -2590,6 +2591,17 @@ mod tests {
 
         assert_eq!(drain_warnings(&mut app).len(), 1);
         assert!(drain_commands(&mut app).is_empty());
+    }
+
+    #[test]
+    fn wgpu_settings_request_compute_capable_limits() {
+        let settings = patinae_wgpu_settings();
+        let limits = settings.device_required_limits;
+
+        assert!(limits.max_compute_workgroups_per_dimension > 0);
+        assert!(limits.max_compute_invocations_per_workgroup >= 64);
+        assert!(limits.max_storage_buffer_binding_size > 0);
+        assert!(limits.max_storage_textures_per_shader_stage > 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Initialize Patinae's native WGPU settings with `wgpu::Limits::default()` before applying the renderer-specific storage-buffer count.

Slint's `WGPUSettings::default()` uses WebGL2-compatible downlevel limits. On the Windows automatic WGPU path this leaves compute and storage limits at zero, so Patinae successfully acquires the GPU and loads structures but cannot create its compute pipelines or scene-store bindings.

This change:

* replaces the zeroed WebGL2/downlevel device limits with normal WebGPU defaults for the native renderer;
* preserves Patinae's existing `max_storage_buffers_per_shader_stage` override;
* adds a regression test ensuring the settings expose non-zero compute/storage capability.

## Reproduction

Observed on Windows with Intel HD Graphics 530 / DX12 after #28.

Before:

```text
wgpu device limits: max_storage_buffer_binding_size=0 ... max_compute_workgroups_per_dimension=0
...
Shader entry point's workgroup size [64, 1, 1] ... limit ... [0, 0, 0]
...
Buffer binding ... exceeds `max_*_buffer_binding_size` limit 0
```

After the change:

```text
wgpu Windows configuration: backends=Backends(DX12) requested max_storage_buffer_binding_size=134217728 max_buffer_size=268435456 max_storage_buffers_per_shader_stage=10
wgpu device limits: max_storage_buffer_binding_size=134217728 max_buffer_size=268435456 max_compute_workgroups_per_dimension=65535 max_texture_dimension_2d=16384
GPU: Intel(R) HD Graphics 530 (Dx12)
```

The same structure then renders successfully on that machine.

## Notes

The non-Windows path already replaces Slint's settings with adapter-derived limits before `request_device`; the Windows automatic path relies directly on `WGPUSettings`, which is why the zeroed defaults surfaced there.
